### PR TITLE
Fix Error's meta property typing

### DIFF
--- a/packages/engine-core/src/Engine.ts
+++ b/packages/engine-core/src/Engine.ts
@@ -30,14 +30,14 @@ export interface RequestError {
   user_facing_error: {
     is_panic: boolean
     message: string
-    meta?: Object
+    meta?: object
     error_code?: string
   }
 }
 
 export class PrismaClientKnownRequestError extends Error {
   code: string
-  meta?: Object
+  meta?: object
   constructor(message: string, code: string, meta?: any) {
     super(message)
     this.code = code

--- a/packages/photon/src/generation/generateClient.ts
+++ b/packages/photon/src/generation/generateClient.ts
@@ -303,7 +303,7 @@ export declare type parseDotenv = any
 
 export declare class PrismaClientKnownRequestError extends Error {
   code: string;
-  meta?: Object;
+  meta?: object;
   constructor(message: string, code: string, meta?: any);
 }
 


### PR DESCRIPTION
`Object` type does not allow to use its data by property key: 

```typescript
const error = new PrismaClientKnownRequestError(
  'test error',
  'P0000',
  { fieldName: 'test-field-name' }
);

console.log(error.meta.fieldName); 

// Typescript error: Property 'fieldName' does not exist on type 'Object'
```