### PR TITLE
Fix downloading HTTPS file with HTTP proxy

### DIFF
--- a/packages/fetch-engine/src/getProxyAgent.ts
+++ b/packages/fetch-engine/src/getProxyAgent.ts
@@ -85,13 +85,11 @@ export function getProxyAgent(url: string): HttpAgent | HttpsAgent | undefined {
     return undefined
   }
 
-  const proxyUri = Url.parse(proxy)
-
-  if (proxyUri.protocol === 'http:') {
+  if (uri.protocol === 'http:') {
     return new HttpProxyAgent(proxy) as HttpAgent
   }
 
-  if (proxyUri.protocol === 'https:') {
+  if (uri.protocol === 'https:') {
     return new HttpsProxyAgent(proxy) as HttpsAgent
   }
 


### PR DESCRIPTION
HttpProxyAgent connects to a specified HTTP or HTTPS proxy server for **HTTP requests**.
HttpsProxyAgent connects to a specified HTTP or HTTPS proxy server for **HTTPS requests**.

So we should choose agent based on the destination instead of the proxy URL.