### PR TITLE
Fix a typo in the generated docs

### DIFF
--- a/packages/photon/src/generation/TSClient.ts
+++ b/packages/photon/src/generation/TSClient.ts
@@ -901,7 +901,7 @@ const ${lowerCase(mapping.model)} = await ${method}({
     // ... provide filter here
   },
   data: {
-    // ... provider data here
+    // ... provide data here
   }
 })
 `
@@ -919,7 +919,7 @@ const ${lowerCase(mapping.model)} = await ${method}({
     // ... provide filter here
   },
   data: {
-    // ... provider data here
+    // ... provide data here
   }
 })
 `


### PR DESCRIPTION
This simply fixes a small typo I have noticed today while checking the docs popup in VS code.