### PR TITLE
chore(github issue template): add npx to prisma -v

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,7 +43,7 @@ Do not include your database credentials when sharing your Prisma schema! -->
 - Database: <!--[PostgreSQL, MySQL, MariaDB or SQLite]-->
 - Node.js version: <!--[Run `node -v` to see your Node.js version]-->
 - Prisma version:
-<!--[Run `prisma -v` to see your Prisma version and paste it between the ´´´]-->
+<!--[Run `npx prisma -v` to see your Prisma version and paste it between the ´´´]-->
 ```
 
 ```


### PR DESCRIPTION
people keep reporting their Prisma 1 version as they have Prisma 1 globally installed.