### PR TITLE
fix: pin stale action version

### DIFF
--- a/.github/workflows/label-stale-issues.yml
+++ b/.github/workflows/label-stale-issues.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v3.0.9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'DUMMY, FOR ENABLING'


### PR DESCRIPTION
Until https://github.com/actions/stale/issues/173 is fixed, we pin the version.